### PR TITLE
Add test for PRMergeBranch

### DIFF
--- a/src/test/kotlin/org/dummy/gsddays/PRMergeBranchTest.kt
+++ b/src/test/kotlin/org/dummy/gsddays/PRMergeBranchTest.kt
@@ -1,0 +1,11 @@
+package org.dummy.gsddays
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PRMergeBranchTest {
+    @Test
+    fun it_should_match() {
+        assertThat(PRMergeBranch().value).isEqualTo(42)
+    }
+}


### PR DESCRIPTION
This PR is intended to fail after merging #29 since `value` changed and Actions should build the code using the `PR merge branch` instead of the `HEAD Branch`