### PR TITLE
PR for showing the different build strategies used by Actions and CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,7 @@ jobs:
       JVM_OPTS: -Xmx3200m
 
     steps:
-      - checkout:
-          post:
-            git pull origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+      - checkout
 
       # Download and cache dependencies
       - restore_cache:
@@ -163,8 +161,8 @@ jobs:
       # run tests!
       - run:
           command: |
-            git status
-            git log -n 3
+            # Workaraund to merge with the TARGET branch.
+            git pull origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
             ./gradlew test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,9 @@ jobs:
             git pull origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
             ./gradlew test
 
+      - store_test_results:
+          path: build/test-results/test
+
 workflows:
   version: 2
   pr_branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,41 @@ jobs:
       # Build the JAR file
       - run: ./gradlew bootJar
 
+  pr_branch:
+    docker:
+      - image: circleci/openjdk:11-jdk
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout:
+          post:
+            git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.gradle.kts" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: ./gradlew dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle.kts" }}
+
+      # run tests!
+      - run: ./gradlew test
+
 workflows:
   version: 2
+  pr_branch:
+    jobs:
+      - pr_branch
   build_and_test:
     jobs:
       - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - checkout:
           post:
-            git pull --ff-only origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
+            git pull origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
 
       # Download and cache dependencies
       - restore_cache:
@@ -161,7 +161,11 @@ jobs:
           key: v1-dependencies-{{ checksum "build.gradle.kts" }}
 
       # run tests!
-      - run: ./gradlew test
+      - run:
+          command: |
+            git status
+            git log -n 3
+            ./gradlew test
 
 workflows:
   version: 2

--- a/.github/workflows/feature-branch-head.yml
+++ b/.github/workflows/feature-branch-head.yml
@@ -1,0 +1,22 @@
+name: Feature Branch HEAD
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Tests
+        run: ./gradlew clean check integrationTest

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -9,7 +9,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/src/test/kotlin/org/dummy/gsddays/PRMergeBranchTest.kt
+++ b/src/test/kotlin/org/dummy/gsddays/PRMergeBranchTest.kt
@@ -1,0 +1,11 @@
+package org.dummy.gsddays
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PRMergeBranchTest {
+    @Test
+    fun it_should_match() {
+        assertThat(PRMergeBranch().value).isEqualTo(42)
+    }
+}


### PR DESCRIPTION
This PR is **intended to fail** after merging #29 since `PRMergeBranch.value` changed (but not the test) and Actions should build the code using the `PR merge branch` instead of the `HEAD` Branch

## Background

Whenever a job starts on the CI, the CI Provider must point out to a specific commit to build the project, and there are different possible choices here:
- Building the commit SHA that generated the PR – HEAD branch.
- Building the merge between the HEAD and the TARGET branch.
- Building both.

This decision might be made by either the CI Platform or the user (if the CI Platform allows customise this behaviour).

## Goal

The goal is to check how both **Github Actions** and **CircleCI** do this with the minimal (or even default) configuration.

### Steps to Reproduce

To test this behaviour, the use case decided is quite simple.

1. In the initial stage, the base (`A`) branch contains a hardcoded value `PRMergeBranch.value` set to `42`.
2. Two branches start from `A`: `B` and `C`. 
3. In the branch `B`, this values changes to `45` – This branch is merged into `A`
4. The branch `C` is now in a _stale_ status since it does not contain the changes introduced by `B`.
5. Build the branch `C` to check the behaviours of both **Github Actions** and **CircleCI**.

## Result

### CircleCI

CircleCI, with the default configuration (showed below), uses the HEAD to build the project, which makes tests to pass successfully since the HEAD branch is in a correct status.

```yml
steps:
  - checkout
```

![Screenshot 2020-04-18 at 13 38 35](https://user-images.githubusercontent.com/345555/79636711-f5051b80-8179-11ea-89ee-4a7ec9f72314.png)

On the other hand, on CircleCI one can simulate the Github Actions default behaviour of building the PR Merge branch even though [there is no official](https://ideas.circleci.com/ideas/CCI-I-926) support for this. This is how the workaround looks like:

```yaml
  - run:
      command: |
        # Workaraund to merge with the TARGET branch.
        git pull origin "refs/pull/${CI_PULL_REQUEST//*pull\//}/merge"
        ./gradlew test
```

### Github Actions

Github Actions, with a pretty much default configuration as well (showed bellow), build the project using the PR Merge branch, which is the merge between the HEAD and the Target branches. This causes the test to fail, since the state introduced by merging the `A` branch (which changed because of `B`) is not the expected by the tests in `C`.

```yml
on:
  pull_request:
    branches:
      - master
# [...]
    steps:
      - uses: actions/checkout@v2
```

![Screenshot 2020-04-18 at 13 48 20](https://user-images.githubusercontent.com/345555/79636877-5a0d4100-817b-11ea-814a-cc1106789ab3.png)

In addition, Github Actions allows to change the behaviour of the built-in `checkout` step so that one can define which branch to point to. With the following configuration, we can emulate the behaviour that CircleCI provides:

```yml
name: Feature Branch HEAD

on:
  pull_request:
    branches:
      - master
# [...]
    steps:
      - uses: actions/checkout@v2
        with:
          ref: ${{ github.event.pull_request.head.sha }}
```

Head to the [official documentation for more scenarios](https://github.com/actions/checkout#scenarios).

## Summary

Both Github Actions and CircleCI can build the PR Merge branch as well as the HEAD branch, but the default behaviour is different, where Actions builds the PR Merge Branch, CircleCI builds the HEAD branch. Also, in both Actions and CircleCI this default behaviour can be customized, being Actions the most flexible and CircleCI relies on customers workaround to achieve the goal.

![Screenshot 2020-04-19 at 14 05 38](https://user-images.githubusercontent.com/345555/79687371-17b13600-8247-11ea-9f03-3288ddded215.png)


